### PR TITLE
Replace reference to char with w:char to fix #5

### DIFF
--- a/lib/ydocx/parser.rb
+++ b/lib/ydocx/parser.rb
@@ -232,7 +232,7 @@ module YDocx
               end
             end
             unless r.xpath('w:sym').empty?
-              code = r.xpath('w:sym').first['char'].downcase # w:char
+              code = r.xpath('w:sym').first['w:char'].downcase # w:char
               content << character_replace(code)
               pos += 1
             end


### PR DESCRIPTION
Assuming that this is a bug. It might instead be something to do with different versions of Word, in which case something more complex might be required.
