### PR TITLE
Namespace the image attrs with r:

### DIFF
--- a/lib/ydocx/parser.rb
+++ b/lib/ydocx/parser.rb
@@ -158,19 +158,19 @@ module YDocx
       ns = r.namespaces.merge additional_namespaces
       [
         { # old type shape
-          :attr => 'id',
+          :attr => 'r:id',
           :path => 'w:pict//v:shape//v:imagedata',
           :wrap => 'w:pict//v:shape//w10:wrap',
           :type => '',
         },
         { # in anchor
-          :attr => 'embed',
+          :attr => 'r:embed',
           :path => 'w:drawing//wp:anchor//a:graphic//a:graphicData//pic:pic//pic:blipFill//a:blip',
           :wrap => 'w:drawing//wp:anchor//wp:wrapTight',
           :type => 'wrapText',
         },
         { # stand alone
-          :attr => 'embed',
+          :attr => 'r:embed',
           :path => 'w:drawing//a:graphic//a:graphicData//pic:pic//pic:blipFill//a:blip',
           :wrap => 'w:drawing//wp:wrapTight',
           :type => 'wrapText',


### PR DESCRIPTION
The images were being found, but they couldn't be mapped to the right
relationship because the attr value is namespaced. I'm just adding
the 'r:' namespace to the values.

Note that I'm not familiar enough with the file format or this gem
to say that this is the right way for all docx files. I have only tested
with a collection of Word 2011 files all from the same sender.